### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,38 @@
+name: Dependabot auto-merge
+
+# Runs after the "CI" workflow finishes. If CI succeeded on a Dependabot pull
+# request, the PR is squash-merged automatically. A workflow_run trigger is used
+# (rather than the usual `gh pr merge --auto`) because `main` has no required
+# status checks, so native auto-merge has nothing to wait on and would error.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Merge Dependabot PR if CI passed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+            --jq '.[] | select(.state == "open" and .user.login == "dependabot[bot]") | .number' \
+            | head -n1)
+          if [ -z "$pr" ]; then
+            echo "No open Dependabot PR found for commit $HEAD_SHA; nothing to merge."
+            exit 0
+          fi
+          echo "CI passed for Dependabot PR #$pr — squash-merging."
+          gh pr merge "$pr" --repo "$REPO" --squash --delete-branch

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,14 +1,10 @@
 name: Dependabot auto-merge
 
-# Runs after the "CI" workflow finishes. If CI succeeded on a Dependabot pull
-# request, the PR is squash-merged automatically. A workflow_run trigger is used
-# (rather than the usual `gh pr merge --auto`) because `main` has no required
-# status checks, so native auto-merge has nothing to wait on and would error.
-on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
+# Enables GitHub native auto-merge on Dependabot PRs. Once the required status
+# checks on `main` pass, GitHub squash-merges the PR automatically. This relies
+# on branch protection requiring CI checks — without required checks, auto-merge
+# has nothing to wait on and would error with "Pull request is in clean status".
+on: pull_request_target
 
 permissions:
   contents: write
@@ -17,22 +13,19 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - name: Merge Dependabot PR if CI passed
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Merge everything that passes CI. To restrict to patch/minor only, add to
+      # the condition below, e.g.:
+      #   if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: |
-          pr=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
-            --jq '.[] | select(.state == "open" and .user.login == "dependabot[bot]") | .number' \
-            | head -n1)
-          if [ -z "$pr" ]; then
-            echo "No open Dependabot PR found for commit $HEAD_SHA; nothing to merge."
-            exit 0
-          fi
-          echo "CI passed for Dependabot PR #$pr — squash-merging."
-          gh pr merge "$pr" --repo "$REPO" --squash --delete-branch


### PR DESCRIPTION
Adds `.github/workflows/dependabot-automerge.yml` so Dependabot PRs merge themselves once CI passes — no more manual merging like #7.

## How it works
- Triggers on `pull_request_target` for PRs opened by `dependabot[bot]`.
- Fetches Dependabot metadata, then enables GitHub **native auto-merge** (`gh pr merge --auto --squash --delete-branch`).
- GitHub completes the squash-merge automatically once the required CI status checks on `main` go green.

## Requires branch protection
This relies on `main` requiring the CI status checks (now configured). Without required checks, native auto-merge has nothing to wait on and errors with "Pull request is in clean status".

## Notes
- Currently merges **all** Dependabot updates that pass CI. To restrict to patch/minor, gate on `steps.metadata.outputs.update-type` (example commented in the workflow).
- Must land on `main` to take effect.